### PR TITLE
fix: dev: Change static path to shared_dir attribute

### DIFF
--- a/lib/topology_docker_openswitch/openswitch.py
+++ b/lib/topology_docker_openswitch/openswitch.py
@@ -103,7 +103,8 @@ def create_interfaces():
             raise Exception('Failed to map ports with port labels')
 
     # Writting mapping to file
-    with open('/tmp/port_mapping.json', 'w') as json_file:
+    shared_dir_tmp = str(__file__).split('openswitch_setup.py')[0]
+    with open('{}/port_mapping.json'.format(shared_dir_tmp), 'w') as json_file:
         json_file.write(dumps(mapping_ports))
 
     for hwport in hwports:
@@ -303,12 +304,14 @@ class OpenSwitchNode(DockerNode):
             fd.write(SETUP_SCRIPT)
 
         try:
-            self._docker_exec('python /tmp/openswitch_setup.py -d')
+            self._docker_exec('python {}/openswitch_setup.py -d'
+                              .format(self.shared_dir_mount))
         except Exception as e:
             check_call('touch {}/logs'.format(self.shared_dir), shell=True)
             check_call('chmod 766 {}/logs'.format(self.shared_dir),
                        shell=True)
-            self._docker_exec('/bin/bash /tmp/process_log.sh')
+            self._docker_exec('/bin/bash {}/process_log.sh'
+                              .format(self.shared_dir_mount))
             check_call(
                 'tail -n 2000 /var/log/syslog > {}/syslog'.format(
                     self.shared_dir

--- a/lib/topology_docker_openswitch/openswitch.py
+++ b/lib/topology_docker_openswitch/openswitch.py
@@ -35,7 +35,7 @@ SETUP_SCRIPT = """\
 import logging
 from sys import argv
 from time import sleep
-from os.path import exists
+from os.path import exists, split
 from json import dumps, loads
 from shlex import split as shsplit
 from subprocess import check_call, check_output
@@ -103,7 +103,7 @@ def create_interfaces():
             raise Exception('Failed to map ports with port labels')
 
     # Writting mapping to file
-    shared_dir_tmp = str(__file__).split('openswitch_setup.py')[0]
+    shared_dir_tmp = split(__file__)[0]
     with open('{}/port_mapping.json'.format(shared_dir_tmp), 'w') as json_file:
         json_file.write(dumps(mapping_ports))
 

--- a/lib/topology_docker_openswitch/plugin/__init__.py
+++ b/lib/topology_docker_openswitch/plugin/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+topology_docker_openswitch module entry point.
+"""

--- a/lib/topology_docker_openswitch/plugin/plugin.py
+++ b/lib/topology_docker_openswitch/plugin/plugin.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2016 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from os.path import exists, basename, splitext
+from os import makedirs
+from shutil import copytree, Error
+from logging import warning
+
+
+def pytest_runtest_teardown(item):
+    """
+    pytest hook to get the name of the test executed, it creates a folder with
+    the name, then copies the folders defined in the shared_dir_mount attribute
+    of each openswitch container, additionally the /var/log/messages of the
+    container is copied to the same folder.
+    """
+    if 'topology' in item.funcargs:
+        topology = item.funcargs['topology']
+        if topology.engine == 'docker':
+            logs_path = '/var/log/messages'
+            for node in topology.nodes:
+                node_obj = topology.get(node)
+                if node_obj.metadata['type'] == 'openswitch':
+                    shared_dir = node_obj.shared_dir
+                    try:
+                        node_obj.send_command(
+                            'cat {} > {}/var_messages.log'.format(
+                                logs_path, node_obj.shared_dir_mount
+                            ),
+                            shell='bash',
+                            silent=True
+                        )
+                    except Error:
+                        warning(
+                            'Unable to get {} from container'.format(logs_path)
+                        )
+                    test_suite = splitext(basename(item.parent.name))[0]
+                    path_name = '/tmp/{}_{}_{}'.format(
+                        test_suite, item.name, str(id(item))
+                    )
+                    if not exists(path_name):
+                        makedirs(path_name)
+                    try:
+                        copytree(
+                            shared_dir, '{}/{}'.format(
+                                path_name,
+                                basename(shared_dir)
+                            )
+                        )
+                    except Error as err:
+                        errors = err.args[0]
+                        for error in errors:
+                            src, dest, msg = error
+                            warning(
+                                'Unable to copy file {}, Error {}'.format(
+                                    src, msg
+                                )
+                            )

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,8 @@ setup(
 
     # Entry points
     entry_points={
+        'pytest11': ['topology_docker_openswitch '
+                     '= topology_docker_openswitch.plugin.plugin'],
         'topology_docker_node_10': [
             'openswitch = topology_docker_openswitch.openswitch:OpenSwitchNode'
         ]


### PR DESCRIPTION
Some static paths were left behind and plugin to move openswitch container logs to test name folder