### PR TITLE
chg: dev: Setting environment container to docker.

### DIFF
--- a/lib/topology_docker_openswitch/openswitch.py
+++ b/lib/topology_docker_openswitch/openswitch.py
@@ -234,6 +234,7 @@ class OpenSwitchNode(DockerNode):
     def __init__(
             self, identifier,
             image='topology/ops:latest', binds=None,
+            environment={'container': 'docker'},
             **kwargs):
 
         # Add binded directories


### PR DESCRIPTION
This is necessary to let the OpenSwitch node that it is running inside a docker container.