### PR TITLE
dev: fix: start openswitch containers without tty

### DIFF
--- a/lib/topology_docker_openswitch/openswitch.py
+++ b/lib/topology_docker_openswitch/openswitch.py
@@ -248,7 +248,7 @@ class OpenSwitchNode(DockerNode):
         super(OpenSwitchNode, self).__init__(
             identifier, image=image, command='/sbin/init',
             binds=';'.join(container_binds), hostname='switch',
-            **kwargs
+            tty=False, **kwargs
         )
 
         # Add vtysh (default) shell


### PR DESCRIPTION
systemd will try to use the TTY if given one (mapped to /dev/console). As the container's init process is most likely detached this TTY will not be functional. This will leave to very slow journaling as systemd tries to write to /dev/console.

Depends on https://github.com/HPENetworking/topology_docker/pull/46